### PR TITLE
prohibit torch 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.8.1
+torch>=1.8.1,<2.0.0 
 torchvision
 numpy
 matplotlib


### PR DESCRIPTION
Pytorch 2.0.0 breaks bsc, possibly more. Forbid until fixed.